### PR TITLE
git lfs pull, not git lfs fetch, to get large files

### DIFF
--- a/www/all-the-data.html
+++ b/www/all-the-data.html
@@ -146,10 +146,10 @@ oid sha256:65ccc4825e65c30f00fcebf1f3d57f4385f18a47e3c5e524114a67050186ae48
 size 71879893
 </pre>
 
-<p>In order to retrieve the contents of the file itself you will need to run <code>git lfs fetch</code>, like this: </p>
+<p>In order to retrieve the contents of the file itself you will need to run <code>git lfs pull</code>, like this: </p>
 
 <pre>
-$> git lfs fetch
+$> git lfs pull
 Fetching master
 (1 of 1 files) 68.54 MB / 68.55 MB
 


### PR DESCRIPTION
As of v0.6.0 of git LFS, you need to run `git lfs pull` to actually install the file. `git lfs fetch` now works similarly to `git fetch`, in that it downloads the objects for the file but doesn't actually update the working copy, so you're left still looking at the metadata.
